### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 A curated, opinionated list of the best **genuinely free** AI tools available right now — real free tiers, open-source projects, and freemium plans where the free tier is actually usable for real work. No "free means 3 generations then paywall." No trial-bait.
 
-**Last updated:** April 24, 2026
+**Last updated:** July 8, 2026
 
 ---
 
@@ -435,6 +435,7 @@ The open-source frontier is no longer just Llama. As of April 2026, Chinese labs
 - **[Aider](https://aider.chat)** — Open-source git-aware terminal pair-programmer. | Free: tool is free; BYOK any LLM | Best for: transparent multi-file edits via diffs | Catch: you pay API costs.
 - **[Claude Code (free routes)](https://claude.com)** — Anthropic's terminal agent. | Free paths: ~$5 API credits at signup; **OSS maintainers get 6 months of Max 20x free** ($1,200 value, Feb 2026 program); community `claude-code-router` pipes CC to free OpenRouter/Gemini models | Best for: highest SWE-bench (80.8%) | Catch: no official free tier — needs $20/mo minimum.
 - **[OpenCode](https://opencode.ai)** — Open-source provider-agnostic terminal coding assistant. | Free: tool is free; pair with Gemini/Groq/Cerebras free | Best for: fully free Claude-Code-style workflow | Catch: younger community.
+- **[Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory)** — Rust CLI/TUI for local-first AI-agent memory lifecycle: SQLite/FTS recall, evidence, audit, forgetting, and consolidation. | Free: MIT open-source, local SQLite storage, no hosted service required | Best for: developers adding persistent memory to local agent workflows | Catch: early-stage and CLI-first; not a standalone chatbot.
 - **[Goose (Block)](https://block.github.io/goose/)** — Open-source local AI agent framework. | Free: BYOK, works with Ollama | Best for: extensible agent workflows | Catch: more framework than polished product.
 - **[Google Antigravity](https://antigravity.google)** — Google's agentic dev platform. | Free: via Google account | Best for: Gemini-native workflows | Catch: new, immature ecosystem.
 

--- a/data/tools.json
+++ b/data/tools.json
@@ -2,7 +2,7 @@
   "meta": {
     "totalTools": 232,
     "totalCategories": 36,
-    "lastUpdated": "2026-04-24",
+    "lastUpdated": "2026-07-08",
     "repoUrl": "https://github.com/mdruhulkuddus/awesome-free-ai-tools"
   },
   "featured": {
@@ -418,6 +418,7 @@
         {"name": "Aider", "url": "https://aider.chat", "description": "Open-source git-aware terminal pair-programmer.", "free": "Tool is free; BYOK any LLM", "bestFor": "Transparent multi-file edits via diffs", "catch": "You pay API costs."},
         {"name": "Claude Code (free routes)", "url": "https://claude.com", "description": "Anthropic's terminal agent. Free paths: ~$5 API signup credits; OSS maintainers get 6 months of Max 20x free (Feb 2026 program); community claude-code-router routes to free OpenRouter/Gemini models.", "free": "~$5 API credits; OSS 6-mo Max 20x program; claude-code-router workaround", "bestFor": "Highest SWE-bench (80.8%)", "catch": "No official free tier — needs $20/mo minimum."},
         {"name": "OpenCode", "url": "https://opencode.ai", "description": "Open-source provider-agnostic terminal coding assistant.", "free": "Tool is free; pair with Gemini/Groq/Cerebras free", "bestFor": "Fully free Claude-Code-style workflow", "catch": "Younger community."},
+        {"name": "Tree Ring Memory", "url": "https://github.com/TerminallyLazy/Tree-Ring-Memory", "description": "Rust CLI/TUI for local-first AI-agent memory lifecycle: SQLite/FTS recall, evidence, audit, forgetting, and consolidation.", "free": "MIT open-source, local SQLite storage, no hosted service required", "bestFor": "Developers adding persistent memory to local agent workflows", "catch": "Early-stage and CLI-first; not a standalone chatbot."},
         {"name": "Goose (Block)", "url": "https://block.github.io/goose/", "description": "Open-source local AI agent framework.", "free": "BYOK, works with Ollama", "bestFor": "Extensible agent workflows", "catch": "More framework than polished product."},
         {"name": "Google Antigravity", "url": "https://antigravity.google", "description": "Google's agentic dev platform.", "free": "Via Google account", "bestFor": "Gemini-native workflows", "catch": "New, immature ecosystem."}
       ]

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Awesome Free AI Tools — 230+ Genuinely Free AI Tools (2026)</title>
-  <meta name="description" content="A curated, opinionated list of 230+ genuinely free AI tools across 35+ categories — real free tiers, open-source projects, no trial-bait, updated April 2026." />
+  <meta name="description" content="A curated, opinionated list of 230+ genuinely free AI tools across 35+ categories — real free tiers, open-source projects, no trial-bait, updated July 2026." />
   <meta name="theme-color" content="#0d1117" />
   <link rel="canonical" href="https://mdruhulkuddus.github.io/awesome-free-ai-tools/" />
 
@@ -105,7 +105,7 @@
         <div class="stat-pills" role="list">
           <span class="stat-pill" role="listitem"><strong>230+</strong> tools</span>
           <span class="stat-pill" role="listitem"><strong>35+</strong> categories</span>
-          <span class="stat-pill" role="listitem">Updated <strong>April 2026</strong></span>
+          <span class="stat-pill" role="listitem">Updated <strong>July 2026</strong></span>
         </div>
         <div class="hero-cta">
           <a class="btn btn-primary" href="#filter-bar">Browse tools</a>


### PR DESCRIPTION
## Summary
- Adds Tree Ring Memory to AI-powered dev tools as a free MIT open-source local-first memory lifecycle tool for agent workflows.
- Updates `data/tools.json` so the website data includes the entry.
- Updates the visible last-updated copy to July 2026.

## Validation
- `python3` JSON parse and rendered-count check passed: one Tree Ring Memory entry in `dev-tools`, rendered total 232, metadata total 232.
- `rg -i "tree ring|tree-ring" README.md data/tools.json index.html script.js` shows exactly the intended README and JSON entries.
- `git diff --check` passed.
- `curl -I -L https://github.com/TerminallyLazy/Tree-Ring-Memory` returned HTTP 200.

Disclosure: I maintain Tree Ring Memory. The entry is framed as early-stage and CLI-first rather than a standalone chatbot.