### PR TITLE
Add Aural to Resume and career AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ Detection tools are imperfect — treat results as signal, not proof.
 - **[Kickresume](https://www.kickresume.com)** — GPT-powered with 1,500+ examples. | Free: basic builder + limited AI | Best for: early-career, design-conscious | Catch: premium templates/downloads paywalled.
 - **[Enhancv](https://enhancv.com)** — Visually rich templates with AI content. | Free: build but limited downloads | Best for: creative roles | Catch: free export is restrictive.
 - **[FlowCV](https://flowcv.com)** — Genuinely free ATS-friendly builder. | Free: unlimited resumes + PDFs, no watermark | Best for: budget-conscious users | Catch: lighter AI than Teal/Rezi.
+- **[Aural](https://github.com/1146345502/aural-oss)** — Open-source AI interview platform for voice, chat, and video. | Free: 3 templates, 100 AI tokens, and 30 session minutes/month; no credit card | Best for: interview practice and small hiring teams | Catch: free plan is limited to 1 seat.
 
 ---
 


### PR DESCRIPTION
Adds Aural to the Resume and career AI section using the required free-tier format.

The entry documents the current free plan: 3 templates, 100 AI tokens, 30 session minutes per month, and 1 seat, with no credit card required.

Project: https://github.com/1146345502/aural-oss

Affiliation: I am the project maintainer.