### PR TITLE
Add AIImageChanger.app to image editing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Every one of these has a meaningful free experience — several are frontier-cla
 
 ## Image editing & enhancement
 
+- **[AIImageChanger.app](https://aiimagechanger.app/)** — Browser editor for changing backgrounds, objects, clothing, colors, and styles with plain-language prompts. | Free: 10 signup credits valid for 30 days | Best for: targeted edits that preserve unchanged details | Catch: continued use requires paid credits.
 - **[Upscayl](https://upscayl.org)** — Open-source desktop upscaler (Real-ESRGAN), up to 16× locally. | Free: unlimited, AGPL-3.0 | Best for: privacy-conscious users, batch work | Catch: needs Vulkan-compatible GPU.
 - **[remove.bg](https://www.remove.bg)** — Industry-standard background remover with excellent hair edges. | Free: unlimited previews + ~1 HD/month | Best for: quick one-off cutouts | Catch: HD downloads are credit-gated.
 - **[Erase.bg](https://www.erase.bg)** — Free full-res BG removal. | Free: HD downloads available | Best for: e-commerce, bulk product shots | Catch: inconsistent on fine hair.


### PR DESCRIPTION
Adds one factual entry to Image editing & enhancement using the documented format.

- Canonical URL: https://aiimagechanger.app/
- Free tier: 10 signup credits valid for 30 days
- Limitation disclosed: continued use requires paid credits
- Affiliation: submitted by the AIImageChanger.app product team

No other entries or files are changed.