### PR TITLE
Add Mydentify AI Watermark and Claude Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ The open-source frontier is no longer just Llama. As of April 2026, Chinese labs
 - **[ZeroGPT](https://www.zerogpt.com)** — Unlimited scans with DeepAnalyse. | Free: unlimited, ~15K chars/scan | Best for: quick bulk checks | Catch: independent 2026 testing found 73.8% accuracy and a 20.5% false-positive rate.
 - **[QuillBot AI Detector](https://quillbot.com/ai-content-detector)** — Detector integrated with the QuillBot suite. | Free: unlimited scans, 80-word minimum | Best for: writers already on QuillBot | Catch: upsells to Premium.
 - **[Copyleaks](https://copyleaks.com)** — Enterprise-grade detection. | Free: limited trial scans | Best for: institutions evaluating | Catch: real free tier is thin.
+- **[Mydentify AI Watermark and Claude Checker](https://mydentify.com/tools/ai-watermark-detector)** — Browser-based checker for hidden Unicode characters and observable writing signals in pasted text. | Free: no signup, runs in your browser | Best for: inspecting Claude and other AI-tool text | Catch: it cannot confirm a private statistical watermark, prove authorship, or identify the source model.
 
 Detection tools are imperfect — treat results as signal, not proof.
 


### PR DESCRIPTION
## What this adds

- Adds Mydentify's free browser-based AI Watermark and Claude Checker to the **AI detection & humanizers** section.
- Links directly to the public tool: https://mydentify.com/tools/ai-watermark-detector
- Describes the observable Unicode and writing-signal checks without claiming model attribution or proof of authorship.

## Why it fits

The tool is usable without signup and runs the check in the browser. Its public page says that it can inspect observable hidden characters and style clues, but cannot confirm Anthropic's private statistical watermark or prove authorship. The entry keeps those limitations visible and follows this list's honesty rules.

## Validation

- Confirmed the public tool page returns HTTP 200.
- Confirmed the page's public description says it checks hidden Unicode characters and explains what text-only detection can prove.
- Confirmed this repository did not already contain Mydentify.
- Changed only `README.md` and ran `git diff --check`.

## Disclosure

I maintain Mydentify and am submitting this factual entry from the maintainer account. No reciprocal link, vote, review, payment, sponsorship, or other engagement is requested.
