### PR TITLE
Add Agent QA to free AI-powered dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ The open-source frontier is no longer just Llama. As of April 2026, Chinese labs
 - **[OpenCode](https://opencode.ai)** — Open-source provider-agnostic terminal coding assistant. | Free: tool is free; pair with Gemini/Groq/Cerebras free | Best for: fully free Claude-Code-style workflow | Catch: younger community.
 - **[Goose (Block)](https://block.github.io/goose/)** — Open-source local AI agent framework. | Free: BYOK, works with Ollama | Best for: extensible agent workflows | Catch: more framework than polished product.
 - **[Google Antigravity](https://antigravity.google)** — Google's agentic dev platform. | Free: via Google account | Best for: Gemini-native workflows | Catch: new, immature ecosystem.
+- **[Agent QA](https://github.com/vostride/agent-qa)** — Source-available application QA harness for natural-language web and mobile tests with execution memory and self-healing flows. | Free: package is free to install; provider usage is separate | Best for: teams maintaining browser or mobile QA flows as applications change | Catch: model, browser, or device providers may charge; the current FSL release is not OSI open source.
 
 ---
 

--- a/data/tools.json
+++ b/data/tools.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "totalTools": 232,
+    "totalTools": 233,
     "totalCategories": 36,
     "lastUpdated": "2026-04-24",
     "repoUrl": "https://github.com/mdruhulkuddus/awesome-free-ai-tools"
@@ -419,7 +419,8 @@
         {"name": "Claude Code (free routes)", "url": "https://claude.com", "description": "Anthropic's terminal agent. Free paths: ~$5 API signup credits; OSS maintainers get 6 months of Max 20x free (Feb 2026 program); community claude-code-router routes to free OpenRouter/Gemini models.", "free": "~$5 API credits; OSS 6-mo Max 20x program; claude-code-router workaround", "bestFor": "Highest SWE-bench (80.8%)", "catch": "No official free tier — needs $20/mo minimum."},
         {"name": "OpenCode", "url": "https://opencode.ai", "description": "Open-source provider-agnostic terminal coding assistant.", "free": "Tool is free; pair with Gemini/Groq/Cerebras free", "bestFor": "Fully free Claude-Code-style workflow", "catch": "Younger community."},
         {"name": "Goose (Block)", "url": "https://block.github.io/goose/", "description": "Open-source local AI agent framework.", "free": "BYOK, works with Ollama", "bestFor": "Extensible agent workflows", "catch": "More framework than polished product."},
-        {"name": "Google Antigravity", "url": "https://antigravity.google", "description": "Google's agentic dev platform.", "free": "Via Google account", "bestFor": "Gemini-native workflows", "catch": "New, immature ecosystem."}
+        {"name": "Google Antigravity", "url": "https://antigravity.google", "description": "Google's agentic dev platform.", "free": "Via Google account", "bestFor": "Gemini-native workflows", "catch": "New, immature ecosystem."},
+        {"name": "Agent QA", "url": "https://github.com/vostride/agent-qa", "description": "Source-available application QA harness for natural-language web and mobile tests with execution memory and self-healing flows.", "free": "Package is free to install; provider usage is separate", "bestFor": "Teams maintaining browser or mobile QA flows as applications change", "catch": "Model, browser, or device providers may charge; the current FSL release is not OSI open source."}
       ]
     },
     {


### PR DESCRIPTION
## Summary

Adds Agent QA to the AI-powered dev tools category in both the README and the website's JSON data source.

The entry treats the package itself as free to install while calling out separately configured provider costs and the current non-OSI FSL license. It gives a concrete best-fit use case and catch instead of presenting the project as an unrestricted free service.

## Verification

- parsed `data/tools.json` and confirmed Agent QA appears exactly once
- confirmed the metadata and category-record counts each increase by one
- confirmed the existing duplicate-name and duplicate-URL baselines are unchanged
- confirmed the README contains one synchronized entry
- `node --check script.js`
- `git diff --check`

## Disclosure

I am affiliated with Agent QA and am submitting the project itself.

Agent QA's current release is source-available under FSL-1.1-ALv2 and converts to Apache-2.0 after two years; it should not be classified as OSI open source today. The package is free to install, but model, browser, or device providers configured by a user may charge separately for usage.
