### PR TITLE
Add Luphra to 3D model generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Every one of these has a meaningful free experience — several are frontier-cla
 ## 3D model generation
 
 - **[Meshy](https://www.meshy.ai)** — Text/image-to-3D with textures, animation, and Blender/Unity/Unreal plugins. | Free: 200 credits/month (~20 models) | Best for: game devs, 3D printing | Catch: free outputs non-commercial.
+- **[Luphra](https://www.luphra.com/)** — Prompt-to-matter: turn prompts or sketches into editable 3D and manufactured physical products (starting with 3D printables). | Free: try in the browser | Best for: designers who want a printable/physical part | Catch: early product; manufacturing beyond printables is limited.
 - **[Tripo AI](https://www.tripo3d.ai)** — Fast text/image-to-3D with clean quad topology. | Free: 2,000 signup credits + daily refills | Best for: game characters | Catch: no Blender plugin yet.
 - **[Rodin (Hyper3D)](https://hyper3d.ai)** — Highest photorealistic quality, 4K PBR. | Free: ~10 credits | Best for: hero/marketing assets | Catch: tiny free allocation.
 - **[Hunyuan3D (Tencent, open source)](https://github.com/Tencent/Hunyuan3D-2)** — Sub-60s generation with 8K PBR. | Free: unlimited self-hosted | Best for: no-cap production | Catch: GPU required.

--- a/data/tools.json
+++ b/data/tools.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "totalTools": 232,
+    "totalTools": 233,
     "totalCategories": 36,
     "lastUpdated": "2026-04-24",
     "repoUrl": "https://github.com/mdruhulkuddus/awesome-free-ai-tools"
@@ -306,6 +306,7 @@
       "description": "Text/image-to-3D with free credits and open-source Hunyuan/TripoSR.",
       "tools": [
         {"name": "Meshy", "url": "https://www.meshy.ai", "description": "Text/image-to-3D with textures, animation, and Blender/Unity/Unreal plugins.", "free": "200 credits/month (~20 models)", "bestFor": "Game devs, 3D printing", "catch": "Free outputs non-commercial."},
+        {"name": "Luphra", "url": "https://www.luphra.com/", "description": "Prompt-to-matter: turn prompts or sketches into editable 3D and manufactured physical products (starting with 3D printables).", "free": "Try in the browser", "bestFor": "Designers who want a printable/physical part", "catch": "Early product; manufacturing beyond printables is limited."},
         {"name": "Tripo AI", "url": "https://www.tripo3d.ai", "description": "Fast text/image-to-3D with clean quad topology.", "free": "2,000 signup credits + daily refills", "bestFor": "Game characters", "catch": "No Blender plugin yet."},
         {"name": "Rodin (Hyper3D)", "url": "https://hyper3d.ai", "description": "Highest photorealistic quality, 4K PBR.", "free": "~10 credits", "bestFor": "Hero/marketing assets", "catch": "Tiny free allocation."},
         {"name": "Hunyuan3D (Tencent, open source)", "url": "https://github.com/Tencent/Hunyuan3D-2", "description": "Sub-60s generation with 8K PBR.", "free": "Unlimited self-hosted", "bestFor": "No-cap production", "catch": "GPU required."},


### PR DESCRIPTION
## Summary
- Adds [Luphra](https://www.luphra.com/) after Meshy under **3D model generation** in `README.md` and `data/tools.json`.
- Prompt-to-matter product: prompts/sketches to editable 3D and manufactured physical products (starting with 3D printables).

## Test plan
- [ ] Confirm the README bullet sits after Meshy in ## 3D model generation
- [ ] Confirm `data/tools.json` 3d-generation tools include Luphra after Meshy
- [ ] Confirm no duplicate Luphra entry