### PR TITLE
Add ResumeAI to Resume & career AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ Detection tools are imperfect — treat results as signal, not proof.
 - **[Kickresume](https://www.kickresume.com)** — GPT-powered with 1,500+ examples. | Free: basic builder + limited AI | Best for: early-career, design-conscious | Catch: premium templates/downloads paywalled.
 - **[Enhancv](https://enhancv.com)** — Visually rich templates with AI content. | Free: build but limited downloads | Best for: creative roles | Catch: free export is restrictive.
 - **[FlowCV](https://flowcv.com)** — Genuinely free ATS-friendly builder. | Free: unlimited resumes + PDFs, no watermark | Best for: budget-conscious users | Catch: lighter AI than Teal/Rezi.
+- **[ResumeAI](https://withresumeai.com/)** — Free ATS checker + AI resume builder; publishes State of ATS 2026 (738 employers, 704 portal-verified; Workday 37.9%). | Free: 3 ATS checks/day no account, 10/day free account | Best for: ATS checks without a paywall | Catch: full AI rewrite features are on paid plans.
 
 ---
 


### PR DESCRIPTION
Adds [ResumeAI](https://withresumeai.com/) under **Resume & career AI**.

- Free ATS checker: 3/day no account, 10/day free account
- AI resume builder
- Publishes State of ATS 2026 (738 employers, 704 portal-verified; Workday 37.9%)

Disclosure: I founded ResumeAI. Canonical URL is https://withresumeai.com/ (not resume.ai).